### PR TITLE
Add pytest suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Solitaire
+
+This repository contains a simple command-line Solitaire implementation.
+
+## Running Tests
+
+Install dependencies (pytest is already included in this environment) and run:
+
+```bash
+pytest
+```
+
+The tests cover deck generation, card play logic and basic move operations.

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -1,0 +1,26 @@
+import sys
+sys.path.append('Cards')
+
+from deck import BuildDeck
+from cards import Card
+
+
+def test_build_deck_unique_cards():
+    deck = BuildDeck()
+    deck.deck = deck.generate_deck()  # use ordered deck to avoid shuffle
+    unique = {(c.suit_number, c.rank_number) for c in deck.deck}
+    assert len(deck.deck) == 52
+    assert len(unique) == 52
+
+def test_card_playable_rules():
+    red_six = Card(0, 5)  # 6 of Hearts (Red)
+    black_seven = Card(2, 6)  # 7 of Spades (Black)
+    assert red_six.is_playable(black_seven)
+    assert not black_seven.is_playable(red_six)
+
+def test_card_playable_foundation():
+    lower = Card(0, 5)  # 6 of Hearts
+    higher = Card(0, 6)  # 7 of Hearts
+    assert lower.is_playable_foundation(higher)
+    other_suit = Card(1, 6)  # Diamonds 7
+    assert not lower.is_playable_foundation(other_suit)

--- a/tests/test_moves.py
+++ b/tests/test_moves.py
@@ -1,0 +1,49 @@
+import sys
+from types import SimpleNamespace
+sys.path.append('Cards')
+
+from cards import Card
+from moves import MoveStock, MoveTableau
+from piles import Stack
+
+
+class DummyTableau:
+    def __init__(self, piles):
+        self.piles = piles
+        self.stock = SimpleNamespace(stock=[])
+        self.foundations = {}
+
+    def __getitem__(self, idx):
+        return self.piles[idx]
+
+
+def test_move_stock_removes_card():
+    stock_cards = [Card(0, 0), Card(1, 1)]
+    tableau = DummyTableau([])
+    tableau.stock = SimpleNamespace(stock=stock_cards)
+    move = MoveStock(tableau)
+    move.find_grab_card()
+    assert move.grab_card == stock_cards[-1]
+    move.remove_grab_card()
+    assert len(stock_cards) == 1
+
+
+def test_move_tableau_is_valid():
+    target_stack = Stack.__new__(Stack)
+    target_stack.row = [Card(2, 6), Card(-1, -1)]  # 7 of Spades then blank
+
+    source_stack = Stack.__new__(Stack)
+    source_stack.row = [Card(0, 5), Card(-1, -1)]  # 6 of Hearts then blank
+
+    tableau = DummyTableau([target_stack, source_stack])
+
+    move = MoveTableau(tableau)
+    move.grab_column = 2
+    move.grab_row = 1
+    move.grab_tableau_column = tableau[1].row[0]
+    move.place_column = 1
+    move.place_tab_col = tableau[0]
+    move.grab_card = move.grab_tableau_column
+    move.place_card = tableau[0].row[0]
+
+    assert move.is_valid()


### PR DESCRIPTION
## Summary
- add pytest tests for deck generation, card logic, and move classes
- document running `pytest`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686da08d16e88320ac9263bba6496e75