### PR TITLE
Implement MoveStock and MoveFoundation input handling

### DIFF
--- a/Cards/moves.py
+++ b/Cards/moves.py
@@ -141,7 +141,10 @@ class MoveStock(Grab):
         place_type = input("Where would you like to place the card? [tableau, foundation]: ").lower()
 
     def req_loc_grab(self):
-        pass
+        """Automatically select the next card from the stock."""
+        if self.stock:
+            # The playable stock card is always the last one in the list
+            self.grab_card = self.stock[-1]
 
     def find_grab_card(self):
         self.grab_card = self.stock[-1]
@@ -160,7 +163,17 @@ class MoveFoundation(Grab):
         self.grab_suit = str(input('What suit would you like to grab from?'))
 
     def req_loc_place(self):
-        pass
+        """Ask the user where the grabbed card should be placed."""
+        destination = input(
+            "Enter tableau column number or foundation suit to place the card: "
+        ).strip()
+
+        if destination.isdigit():
+            self.place_column = int(destination)
+            self.place_suit = None
+        else:
+            self.place_suit = destination
+            self.place_column = None
 
     def find_grab_card(self):
         self.grab_card = self.foundations[self.grab_suit][-1]

--- a/tests/test_moves.py
+++ b/tests/test_moves.py
@@ -1,0 +1,42 @@
+import builtins
+from unittest import mock
+
+import sys
+sys.path.append('Cards')
+
+from deck import BuildDeck
+from piles import Tableau
+from moves import MoveStock, MoveFoundation
+
+
+def setup_tableau():
+    deck = BuildDeck()
+    tableau = Tableau(deck)
+    return tableau
+
+
+def test_move_stock_req_loc_grab_sets_grab_card():
+    tableau = setup_tableau()
+    move = MoveStock(tableau)
+    # before call grab_card is None
+    assert move.grab_card is None
+    move.req_loc_grab()
+    assert move.grab_card is tableau.stock.stock[-1]
+
+
+def test_move_foundation_req_loc_place_column():
+    tableau = setup_tableau()
+    move = MoveFoundation(tableau)
+    with mock.patch.object(builtins, 'input', return_value='3'):
+        move.req_loc_place()
+    assert move.place_column == 3
+    assert move.place_suit is None
+
+
+def test_move_foundation_req_loc_place_suit():
+    tableau = setup_tableau()
+    move = MoveFoundation(tableau)
+    with mock.patch.object(builtins, 'input', return_value='Hearts'):
+        move.req_loc_place()
+    assert move.place_suit == 'Hearts'
+    assert move.place_column is None


### PR DESCRIPTION
## Summary
- implement `MoveStock.req_loc_grab` to automatically select the next stock card
- implement `MoveFoundation.req_loc_place` to collect where a foundation card should be placed
- add unit tests covering these behaviours

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686da0818dc083209c92555e5c020970